### PR TITLE
Port to v8.6:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,13 @@ plugin/*.cmi
 *.ml.d
 *.mlpack.d
 *.cmo
+*.cmt
+*.cmti
 *.cmx
 *.cmxs
 *.o
 *.cmi
+*~
 plugin/theories/.Patch.aux
 plugin/theories/Patch.glob
 plugin/theories/Patch.v.d

--- a/plugin/.merlin
+++ b/plugin/.merlin
@@ -1,0 +1,6 @@
+FLG -rectypes -thread -w @1..50@59-4-44 -safe-string
+
+S src/**
+B src/**
+
+PKG threads threads.posix coq.intf coq.ltac

--- a/plugin/src/core/components/abstraction/abstraction.ml
+++ b/plugin/src/core/components/abstraction/abstraction.ml
@@ -19,6 +19,8 @@ open Proofdiff
 open Searchopts
 open Cutlemma
 
+module CRD = Context.Rel.Declaration
+
 (* Internal options for abstraction *)
 type abstraction_options =
   {
@@ -108,7 +110,7 @@ let get_abstraction_args config : closure =
     else
       match kind_of_term g with
       | Lambda (n, t, b) ->
-	 let en' = push_rel (n, None, t) en in
+	 let en' = push_rel CRD.(LocalAssum(n, t)) en in
 	 let (en'', b') = infer_args (i - 1) en' b in
 	 (en'', (mkRel i) :: b')
       | _ ->

--- a/plugin/src/core/components/differencing/changedetectors.ml
+++ b/plugin/src/core/components/differencing/changedetectors.ml
@@ -12,6 +12,8 @@ open Reducers
 open Assumptions
 open Collections
 
+module CRD = Context.Rel.Declaration
+
 (*
  * If the kind of change is a change in conclusion, then
  * determine whether the first different term is a constructor or
@@ -65,7 +67,7 @@ let find_kind_of_change (cut : cut_lemma option) (d : goal_proof_diff) =
          else
            Conclusion
        else
-         diff (push_rel (n_o, None, t_o) env) b_o b_n
+         diff (push_rel CRD.(LocalAssum(n_o, t_o)) env) b_o b_n
     | (App (f_o, args_o), App (f_n, args_n)) ->
        if (not (same_length args_o args_n)) then
          Conclusion

--- a/plugin/src/core/components/differencing/fixdifferencers.ml
+++ b/plugin/src/core/components/differencing/fixdifferencers.ml
@@ -13,6 +13,8 @@ open Debruijn
 open Differencers
 open Higherdifferencers
 
+module CRD = Context.Rel.Declaration
+
 (* --- Cases --- *)
 
 (*
@@ -38,7 +40,7 @@ let rec get_goal_fix env (d : types proof_diff) : candidates =
     | (Lambda (n1, t1, b1), Lambda (_, t2, b2)) when convertible env t1 t2 ->
        List.map
          (fun c -> mkProd (n1, t1, c))
-         (get_goal_fix (push_rel (n1, None, t1) env) (difference b1 b2 assums))
+         (get_goal_fix (push_rel CRD.(LocalAssum(n1, t1)) env) (difference b1 b2 assums))
     | _ ->
        let reduce_hd = reduce_unfold_whd env in
        let rec get_goal_reduced d =
@@ -62,10 +64,10 @@ let rec diff_fix_case env (d : types proof_diff) : candidates =
   let conv = convertible env in
   match kinds_of_terms (old_term, new_term) with
   | (Lambda (n1, t1, b1), Lambda (_, t2, b2)) when conv t1 t2 ->
-     diff_fix_case (push_rel (n1, None, t1) env) (difference b1 b2 assums)
+     diff_fix_case (push_rel CRD.(LocalAssum(n1, t1)) env) (difference b1 b2 assums)
   | (Case (_, ct1, m1, bs1), Case (_, ct2, m2, bs2)) when conv m1 m2  ->
      if same_length bs1 bs2 then
-       let env_m = push_rel (Anonymous, None, m1) env in
+       let env_m = push_rel CRD.(LocalAssum(Anonymous, m1)) env in
        let diff_bs = diff_map_flat (get_goal_fix env_m) in
        List.map
          unshift

--- a/plugin/src/core/components/differencing/proofdifferencers.ml
+++ b/plugin/src/core/components/differencing/proofdifferencers.ml
@@ -13,6 +13,8 @@ open Filters
 open Candidates
 open Reducers
 
+module CRD = Context.Rel.Declaration
+
 (* --- Utilities --- *)
 
 (*
@@ -74,7 +76,7 @@ let merge_diff_envs is_ind num_new_rels (d : goal_type_term_diff)  =
 let build_app_candidates (env : env) (old_term : types) (new_term : types) =
   try
     let new_type = infer_type env new_term in
-    let env_shift = push_rel (Anonymous, None, new_type) env in
+    let env_shift = push_rel CRD.(LocalAssum(Anonymous, new_type)) env in
     let old_term_shift = shift old_term in
     let new_term_shift = shift new_term in
     let sub = all_conv_substs_combs env_shift (new_term_shift, (mkRel 1)) in

--- a/plugin/src/core/components/factoring/factoring.ml
+++ b/plugin/src/core/components/factoring/factoring.ml
@@ -10,6 +10,8 @@ open Collections
 open Debruijn
 open Printing
 
+module CRD = Context.Rel.Declaration
+
 type factors = (env * types) list
 
 (* --- Assumptions for path finding --- *)
@@ -36,7 +38,7 @@ let is_assumption (env : env) (trm : types) : bool =
  *)
 let assume (env : env) (n : name) (typ : types) : env =
   let env_pop = pop_rel_context 1 env in
-  push_rel (n, None, typ) env_pop
+  push_rel CRD.(LocalAssum(n, typ)) env_pop
 
 (* --- Path-finding auxiliary functionality --- *)
 
@@ -115,7 +117,7 @@ let factor_term (env : env) (trm : types) : factors =
       if is_assumption env body then
 	(env, body)
       else
-	let (n, _, t) = lookup_rel 1 env in
+	let (n, _, t) = CRD.to_tuple @@ lookup_rel 1 env in
 	(pop_rel_context 1 env, mkLambda (n, t, body)))
     path_body
 

--- a/plugin/src/core/components/inversion/inverting.ml
+++ b/plugin/src/core/components/inversion/inverting.ml
@@ -14,6 +14,8 @@ open Hofs
 open Filters
 open Factoring
 
+module CRD = Context.Rel.Declaration
+
 type inverter = (env * types) -> (env * types) option
 
 (* --- Inverting type paths --- *)
@@ -32,7 +34,7 @@ let invert_factors (invert : inverter) (fs : factors) : factors =
   match inverted with (* swap final hypothesis *)
   | (env_inv, trm_inv) :: t when List.length t > 0 ->
      let (n, h_inv, _) = destLambda (snd (last t)) in
-     let env_inv = push_rel (n, None, h_inv) (pop_rel_context 1 env_inv) in
+     let env_inv = push_rel CRD.(LocalAssum(n, h_inv)) (pop_rel_context 1 env_inv) in
      (env_inv, trm_inv) :: t
   | _ ->
      inverted
@@ -135,7 +137,7 @@ let invert_factor (env, rp) : (env * types) option =
   let rp = reduce_term env rp in
   match kind_of_term rp with
   | Lambda (n, old_goal_type, body) ->
-     let env_body = push_rel (n, None, old_goal_type) env in
+     let env_body = push_rel CRD.(LocalAssum(n, old_goal_type)) env in
      let new_goal_type = unshift (reduce_term env_body (infer_type env_body body)) in
      let rp_goal = all_conv_substs env (old_goal_type, new_goal_type) rp in
      let goal_type = mkProd (n, new_goal_type, shift old_goal_type) in

--- a/plugin/src/core/components/specialization/specialization.ml
+++ b/plugin/src/core/components/specialization/specialization.ml
@@ -15,6 +15,8 @@ open Coqterms
 open Reducers
 open Collections
 
+module CRD = Context.Rel.Declaration
+
 type specializer = env -> types -> types array -> types
 
 (* --- Top-level --- *)
@@ -38,7 +40,7 @@ let specialize_using (s : specializer) env f args =
 let rec specialize_body (s : specializer) (env : env) (t : types) : types =
   match kind_of_term t with
   | Lambda (n, t, b) ->
-     mkLambda (n, t, specialize_body s (push_rel (n, None, t) env) b)
+     mkLambda (n, t, specialize_body s (push_rel CRD.(LocalAssum(n, t)) env) b)
   | App (f, args) ->
      let f_body = unwrap_definition env f in
      s env f_body args

--- a/plugin/src/core/configuration/searchopts.ml
+++ b/plugin/src/core/configuration/searchopts.ml
@@ -16,6 +16,8 @@ open Kindofchange
 open Cutlemma
 open Zooming
 
+module CRD = Context.Rel.Declaration
+
 (* --- Auxiliary --- *)
 
 let terms_convertible env_o env_n src_o src_n dst_o dst_n =
@@ -91,8 +93,8 @@ let configure_same_h change (d : lift_goal_diff) : types -> types -> bool =
    let (env_o, env_n) = context_envs goals in
    let env_o' = push_rel rel_o env_o in
    let env_n' = push_rel rel_n env_n in
-   let (_, _, t_o) = rel_o in
-   let (_, _, t_n) = rel_n in
+   let (_, _, t_o) = CRD.to_tuple @@ rel_o in
+   let (_, _, t_n) = CRD.to_tuple @@ rel_n in
    let trim = terms_convertible env_o' env_n' t_o t_n in
    match kinds_of_terms (g_o, g_n) with
    | (Prod (_, t_g_o, b_o), Prod (_, t_g_n, b_n)) when trim t_g_o t_g_n ->
@@ -121,8 +123,8 @@ let update_goals_types d_old d =
   let (new_goal, _) = new_proof d_old in
   match kinds_of_terms (proof_terms d_old) with
   | (Lambda (n_o, t_o, _), Lambda (n_n, t_n, _)) ->
-     let rel_o = (n_o, None, t_o) in
-     let rel_n = (n_n, None, t_n) in
+     let rel_o = CRD.LocalAssum(n_o, t_o) in
+     let rel_n = CRD.LocalAssum(n_n, t_n) in
      let (g_o, g_n) = update_goal_terms (old_goal, new_goal) rel_o rel_n in
      let o = (Context (g_o, fid ()), old_proof d) in
      let n = (Context (g_n, fid ()), new_proof d) in

--- a/plugin/src/library/coq/coqenvs.ml
+++ b/plugin/src/library/coq/coqenvs.ml
@@ -5,12 +5,14 @@ open Term
 open Coqterms
 open Names
 
+module CRD = Context.Rel.Declaration
+
 type 'a contextual = env -> 'a
 
 (* --- General environment management auxiliary functions --- *)
 
 (* Look up all indexes from is in env *)
-let lookup_rels (is : int list) (env : env) : Context.rel_declaration list =
+let lookup_rels (is : int list) (env : env) : CRD.t list =
  List.map (fun i -> lookup_rel i env) is
 
 (* Return a list of all indexes in env, starting with 1 *)
@@ -18,7 +20,7 @@ let all_rel_indexes (env : env) : int list =
   from_one_to (nb_rel env)
 
 (* Return a list of all bindings in env, starting with the closest *)
-let lookup_all_rels (env : env) : Context.rel_declaration list =
+let lookup_all_rels (env : env) : CRD.t list =
   lookup_rels (all_rel_indexes env) env
 
 (*
@@ -27,11 +29,11 @@ let lookup_all_rels (env : env) : Context.rel_declaration list =
  * Note: We need pop_rel_conext (nb_rel env) env rather than empty_env
  * because empty_env does not contain global definitions like nat.
  *)
-let push_last ((n, b, t) : Context.rel_declaration) (env : env) : env =
+let push_last (decl : CRD.t) (env : env) : env =
   List.fold_left
-    (fun en (na, bo, ty) -> push_rel (na, bo, ty) en)
+    (fun en decl -> push_rel decl en)
     (pop_rel_context (nb_rel env) env)
-    ((n, b, t) :: (List.rev (lookup_all_rels env)))
+    (decl :: (List.rev (lookup_all_rels env)))
 
 (* --- Getting bindings for terms --- *)
 
@@ -39,20 +41,20 @@ let push_last ((n, b, t) : Context.rel_declaration) (env : env) : env =
  * Inductive types create bindings that we need to push to the environment
  * This function gets those bindings
  *)
-let bindings_for_inductive (env : env) (mutind_body : mutual_inductive_body) (ind_bodies : one_inductive_body list) : Context.rel_declaration list =
+let bindings_for_inductive (env : env) (mutind_body : mutual_inductive_body) (ind_bodies : one_inductive_body list) : CRD.t list =
   List.map
     (fun ind_body ->
       let name_id = ind_body.mind_typename in
       let typ = type_of_inductive env mutind_body ind_body in
-      (Names.Name name_id, None, typ))
+      CRD.LocalAssum(Names.Name name_id, typ))
     ind_bodies
 
 (*
  * A fixpoint creates bindings that we need to push to the environment
  * This function gets all of those bindings
  *)
-let bindings_for_fix (names : name array) (typs : types array) : Context.rel_declaration list =
+let bindings_for_fix (names : name array) (typs : types array) : CRD.t list =
   Array.to_list
     (CArray.map2_i
-      (fun i name typ -> (name, None, Vars.lift i typ))
+      (fun i name typ -> CRD.LocalAssum (name, Vars.lift i typ))
       names typs)

--- a/plugin/src/library/coq/coqenvs.mli
+++ b/plugin/src/library/coq/coqenvs.mli
@@ -9,16 +9,16 @@ type 'a contextual = env -> 'a
 (* --- General environment management auxiliary functions --- *)
 
 (* Look up all indexes from a list in an environment *)
-val lookup_rels : int list -> env -> rel_declaration list
+val lookup_rels : int list -> env -> Rel.Declaration.t list
 
 (* Return a list of all indexes in an environment, starting with 1 *)
 val all_rel_indexes : env -> int list
 
 (* Return a list of all bindings in an environment, starting with the closest *)
-val lookup_all_rels : env -> rel_declaration list
+val lookup_all_rels : env -> Rel.Declaration.t list
 
 (* Push something to the highest position in an environment *)
-val push_last : rel_declaration -> env -> env
+val push_last : Rel.Declaration.t -> env -> env
 
 (* --- Getting bindings for terms --- *)
 
@@ -26,10 +26,10 @@ val push_last : rel_declaration -> env -> env
  * Inductive types create bindings that we need to push to the environment
  * This function gets those bindings
  *)
-val bindings_for_inductive : env -> mutual_inductive_body -> one_inductive_body list -> rel_declaration list
+val bindings_for_inductive : env -> mutual_inductive_body -> one_inductive_body list -> Rel.Declaration.t list
 
 (*
  * A fixpoint also creates bindings that we need to push to the environment
  * This function gets all of those bindings
  *)
-val bindings_for_fix : name array -> types array -> rel_declaration list
+val bindings_for_fix : name array -> types array -> Rel.Declaration.t list

--- a/plugin/src/library/coq/debruijn.ml
+++ b/plugin/src/library/coq/debruijn.ml
@@ -91,8 +91,8 @@ let unshift_env_by (n : int) (env : env) : env =
   let all_relis = List.rev (from_one_to num_rels) in
   let all_rels = lookup_rels all_relis env in
   List.fold_left
-    (fun env (na, b, t) ->
-      push_rel (na, b, t) env)
+    (fun env decl ->
+      push_rel decl env)
     (pop_rel_context num_rels env)
     all_rels
 

--- a/plugin/src/library/coq/hofs.ml
+++ b/plugin/src/library/coq/hofs.ml
@@ -12,6 +12,8 @@ open Names
 open Utilities
 open Printing
 
+module CRD = Context.Rel.Declaration
+
 (* Predicates to determine whether to apply a mapped function *)
 type ('a, 'b) pred = 'a -> 'b -> bool
 type ('a, 'b) pred_with_env = env -> ('a, 'b) pred
@@ -113,16 +115,16 @@ let rec map_term_env (f : 'a f_with_env) (d : 'a updater) (env : env) (a : 'a) (
      mkCast (c', k, t')
   | Prod (n, t, b) ->
      let t' = map_rec env a t in
-     let b' = map_rec (push_rel (n, None, t) env) (d a) b in
+     let b' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
      mkProd (n, t', b')
   | Lambda (n, t, b) ->
      let t' = map_rec env a t in
-     let b' = map_rec (push_rel (n, None, t) env) (d a) b in
+     let b' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
      mkLambda (n, t', b')
   | LetIn (n, trm, typ, e) ->
      let trm' = map_rec env a trm in
      let typ' = map_rec env a typ in
-     let e' = map_rec (push_rel (n, Some e, typ) env) (d a) e in
+     let e' = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) e in
      mkLetIn (n, trm', typ', e')
   | App (fu, args) ->
      let fu' = map_rec env a fu in
@@ -170,16 +172,16 @@ let rec map_subterms_env (f : 'a f_cart_with_env) (d : 'a updater) (env : env) (
      combine_cartesian (fun c' t' -> mkCast (c', k, t')) cs' ts'
   | Prod (n, t, b) ->
      let ts' = map_rec env a t in
-     let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+     let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
      combine_cartesian (fun t' b' -> mkProd (n, t', b')) ts' bs'
   | Lambda (n, t, b) ->
      let ts' = map_rec env a t in
-     let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+     let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
      combine_cartesian (fun t' b' -> mkLambda (n, t', b')) ts' bs'
   | LetIn (n, trm, typ, e) ->
      let trms' = map_rec env a trm in
      let typs' = map_rec env a typ in
-     let es' = map_rec (push_rel (n, Some e, typ) env) (d a) e in
+     let es' = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) e in
      combine_cartesian (fun trm' (typ', e') -> mkLetIn (n, trm', typ', e')) trms' (cartesian typs' es')
   | App (fu, args) ->
      let fus' = map_rec env a fu in
@@ -232,16 +234,16 @@ let rec map_term_env_if (p : 'a p_with_env) (f : 'a f_with_env) (d : 'a updater)
        mkCast (c', k, t')
     | Prod (n, t, b) ->
        let t' = map_rec env a t in
-       let b' = map_rec (push_rel (n, None, t') env) (d a) b in
+       let b' = map_rec (push_rel CRD.(LocalAssum(n, t')) env) (d a) b in
        mkProd (n, t', b')
     | Lambda (n, t, b) ->
        let t' = map_rec env a t in
-       let b' = map_rec (push_rel (n, None, t') env) (d a) b in
+       let b' = map_rec (push_rel CRD.(LocalAssum(n, t')) env) (d a) b in
        mkLambda (n, t', b')
     | LetIn (n, trm, typ, e) ->
        let trm' = map_rec env a trm in
        let typ' = map_rec env a typ in
-       let e' = map_rec (push_rel (n, Some e, typ') env) (d a) e in
+       let e' = map_rec (push_rel CRD.(LocalDef(n, e, typ')) env) (d a) e in
        mkLetIn (n, trm', typ', e')
     | App (fu, args) ->
        let fu' = map_rec env a fu in
@@ -287,16 +289,16 @@ let rec map_term_env_if_shallow (p : 'a p_with_env) (f : 'a f_with_env) (d : 'a 
        mkCast (c', k, t')
     | Prod (n, t, b) ->
        let t' = map_rec env a t in
-       let b' = map_rec (push_rel (n, None, t') env) (d a) b in
+       let b' = map_rec (push_rel CRD.(LocalAssum(n, t')) env) (d a) b in
        mkProd (n, t', b')
     | Lambda (n, t, b) ->
        let t' = map_rec env a t in
-       let b' = map_rec (push_rel (n, None, t') env) (d a) b in
+       let b' = map_rec (push_rel CRD.(LocalAssum(n, t')) env) (d a) b in
        mkLambda (n, t', b')
     | LetIn (n, trm, typ, e) ->
        let trm' = map_rec env a trm in
        let typ' = map_rec env a typ in
-       let e' = map_rec (push_rel (n, Some e, typ') env) (d a) e in
+       let e' = map_rec (push_rel CRD.(LocalDef(n, e, typ')) env) (d a) e in
        mkLetIn (n, trm', typ', e')
     | App (fu, args) ->
        let fu' = map_rec env a fu in
@@ -355,16 +357,16 @@ let rec map_subterms_env_if (p : 'a p_with_env) (f : 'a f_cart_with_env) (d : 'a
        combine_cartesian (fun c' t' -> mkCast (c', k, t')) cs' ts'
     | Prod (n, t, b) ->
        let ts' = map_rec env a t in
-       let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+       let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
        combine_cartesian (fun t' b' -> mkProd (n, t', b')) ts' bs'
     | Lambda (n, t, b) ->
        let ts' = map_rec env a t in
-       let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+       let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
        combine_cartesian (fun t' b' -> mkLambda (n, t', b')) ts' bs'
     | LetIn (n, trm, typ, e) ->
        let trms' = map_rec env a trm in
        let typs' = map_rec env a typ in
-       let es' = map_rec (push_rel (n, Some e, typ) env) (d a) e in
+       let es' = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) e in
        combine_cartesian (fun trm' (typ', e') -> mkLetIn (n, trm', typ', e')) trms' (cartesian typs' es')
     | App (fu, args) ->
        let fus' = map_rec env a fu in
@@ -409,16 +411,16 @@ let rec map_subterms_env_if_combs (p : 'a p_with_env) (f : 'a f_cart_with_env) (
          combine_cartesian (fun c' t' -> mkCast (c', k, t')) cs' ts'
       | Prod (n, t, b) ->
          let ts' = map_rec env a t in
-         let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+         let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
          combine_cartesian (fun t' b' -> mkProd (n, t', b')) ts' bs'
       | Lambda (n, t, b) ->
          let ts' = map_rec env a t in
-         let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+         let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
          combine_cartesian (fun t' b' -> mkLambda (n, t', b')) ts' bs'
       | LetIn (n, trm, typ, e) ->
          let trms' = map_rec env a trm in
          let typs' = map_rec env a typ in
-         let es' = map_rec (push_rel (n, Some e, typ) env) (d a) e in
+         let es' = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) e in
          combine_cartesian (fun trm' (typ', e') -> mkLetIn (n, trm', typ', e')) trms' (cartesian typs' es')
       | App (fu, args) ->
          let fus' = map_rec env a fu in
@@ -464,16 +466,16 @@ let rec map_subterms_env_if_lazy (p : 'a p_with_env) (f : 'a f_cart_with_env) (d
        combine_cartesian (fun c' t' -> mkCast (c', k, t')) cs' ts'
     | Prod (n, t, b) ->
        let ts' = map_rec env a t in
-       let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+       let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
        combine_cartesian (fun t' b' -> mkProd (n, t', b')) ts' bs'
     | Lambda (n, t, b) ->
        let ts' = map_rec env a t in
-       let bs' = map_rec (push_rel (n, None, t) env) (d a) b in
+       let bs' = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) b in
        combine_cartesian (fun t' b' -> mkLambda (n, t', b')) ts' bs'
     | LetIn (n, trm, typ, e) ->
        let trms' = map_rec env a trm in
        let typs' = map_rec env a typ in
-       let es' = map_rec (push_rel (n, Some e, typ) env) (d a) e in
+       let es' = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) e in
        combine_cartesian (fun trm' (typ', e') -> mkLetIn (n, trm', typ', e')) trms' (cartesian typs' es')
     | App (fu, args) ->
        let fus' = map_rec env a fu in
@@ -527,16 +529,16 @@ let rec map_eterm_env (f : 'a fe_with_env) (d : 'a updater) (env : env) (a : 'a)
      (evm'', mkCast (c', k, t'))
   | Prod (n, t, b) ->
      let (evm', t') = map_rec env a (evm, t) in
-     let (evm'', b') = map_rec (push_rel (n, None, t) env) (d a) (evm', b) in
+     let (evm'', b') = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) (evm', b) in
      (evm'', mkProd (n, t', b'))
   | Lambda (n, t, b) ->
      let (evm', t') = map_rec env a (evm, t) in
-     let (evm'', b') = map_rec (push_rel (n, None, t) env) (d a) (evm', b) in
+     let (evm'', b') = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) (evm', b) in
      (evm'', mkLambda (n, t', b'))
   | LetIn (n, trm, typ, e) ->
      let (evm', trm') = map_rec env a (evm, trm) in
      let (evm'', typ') = map_rec env a (evm', typ) in
-     let (evm''', e') = map_rec (push_rel (n, Some e, typ) env) (d a) (evm'', e) in
+     let (evm''', e') = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) (evm'', e) in
      (evm''', mkLetIn (n, trm', typ', e'))
   | App (fu, args) ->
      let (evm', fu') = map_rec env a (evm, fu) in
@@ -587,16 +589,16 @@ let rec map_eterm_env_if_lazy (p : 'a pe_with_env) (f : 'a fe_with_env) (d : 'a 
        (evm'', mkCast (c', k, t'))
     | Prod (n, t, b) ->
        let (evm', t') = map_rec env a (evm, t) in
-       let (evm'', b') = map_rec (push_rel (n, None, t) env) (d a) (evm', b) in
+       let (evm'', b') = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) (evm', b) in
        (evm'', mkProd (n, t', b'))
     | Lambda (n, t, b) ->
        let (evm', t') = map_rec env a (evm, t) in
-       let (evm'', b') = map_rec (push_rel (n, None, t) env) (d a) (evm', b) in
+       let (evm'', b') = map_rec (push_rel CRD.(LocalAssum(n, t)) env) (d a) (evm', b) in
        (evm'', mkLambda (n, t', b'))
     | LetIn (n, trm, typ, e) ->
        let (evm', trm') = map_rec env a (evm, trm) in
        let (evm'', typ') = map_rec env a (evm', typ) in
-       let (evm''', e') = map_rec (push_rel (n, Some e, typ) env) (d a) (evm'', e) in
+       let (evm''', e') = map_rec (push_rel CRD.(LocalDef(n, e, typ)) env) (d a) (evm'', e) in
        (evm''', mkLetIn (n, trm', typ', e'))
     | App (fu, args) ->
        let (evm', fu') = map_rec env a (evm, fu) in

--- a/plugin/src/library/proofsearch/compilation/evaluation.ml
+++ b/plugin/src/library/proofsearch/compilation/evaluation.ml
@@ -13,6 +13,8 @@ open Substitution
 open Declarations
 open Printing
 
+module CRD = Context.Rel.Declaration
+
 (*
  * Evaluate typ one step in env
  * Then bind the single anonymous arrow to e
@@ -49,7 +51,7 @@ let rec induction_constrs (nc : int) (env : env) ((n, t, b) : Name.t * types * t
   if nc = 0 then
     []
   else
-    let e = LazyBinding (mkRel 1, push_rel (n, None, t) env) in
+    let e = LazyBinding (mkRel 1, push_rel CRD.(LocalAssum(n, t)) env) in
     let c = eval_theorem_bind e env t in
     match kind_of_term b with
     | Prod (n', t', b') ->

--- a/plugin/src/library/proofsearch/compilation/expansion.ml
+++ b/plugin/src/library/proofsearch/compilation/expansion.ml
@@ -13,6 +13,8 @@ open Utilities
 open Debruijn
 open Printing
 
+module CRD = Context.Rel.Declaration
+
 (* --- Type definitions --- *)
 
 type 'a expansion_strategy = 'a -> 'a
@@ -22,7 +24,7 @@ type 'a expansion_strategy = 'a -> 'a
 (* Expand a product type exactly once *)
 let expand_product (env : env) ((n, t, b) : Name.t * types * types) : proof_cat =
   let t' = eval_theorem env t in
-  let env' = push_rel (n, None, t) env in
+  let env' = push_rel CRD.(LocalAssum(n, t)) env in
   let b' = eval_theorem env' b in
   let c = substitute_categories t' b' in
   bind c (initial c, LazyBinding (mkRel 1, env'), terminal t')
@@ -101,7 +103,7 @@ let expand_product_fully (o : context_object) : proof_cat =
     match kind_of_term b with
     | Prod (n', t', b') ->
        let t'' = eval_theorem env t in
-       let env' = push_rel (n, None, t) env in
+       let env' = push_rel CRD.(LocalAssum(n, t)) env in
        let b'' = expand_fully env' (n', t', b') in
        let c = substitute_categories t'' b'' in
        bind c (initial c, LazyBinding (mkRel 1, env'), terminal t'')
@@ -208,7 +210,7 @@ let applies_ih (en : env) (p : types) (c : proof_cat) : context_object -> bool =
  *)
 let bind_ihs (c : proof_cat) : proof_cat =
   let env_with_p = context_env (context_at_index c 1) in
-  let (_, _, p) = lookup_rel 1 env_with_p in
+  let (_, _, p) = CRD.to_tuple @@ lookup_rel 1 env_with_p in
   let env = pop_rel_context 1 env_with_p in
   apply_functor
     id

--- a/plugin/src/library/proofsearch/representation/assumptions.ml
+++ b/plugin/src/library/proofsearch/representation/assumptions.ml
@@ -9,6 +9,8 @@ open Printing
 open Coqterms
 open Hofs
 
+module CRD = Context.Rel.Declaration
+
 (* For now, these are lists of pairs of ints, each int representing
    an index in a different environment; this representation
    is hard to use, so may change this in the future (TODO) *)
@@ -211,9 +213,10 @@ let substitute_env_params (subs : param_substitutions) (env : env) : env =
   let all_rels = List.rev (lookup_all_rels env) in
   snd
     (List.fold_left
-     (fun (s, env) (n, b, t) ->
+     (fun (s, env) decl ->
        let sub = substitute_params s in
-       (shift_substitutions s, push_rel (n, Option.map sub b, sub t) env))
+       let decl = CRD.map_constr sub decl in
+       (shift_substitutions s, push_rel decl env))
      (unshift_substitutions_by num_rels subs, pop_rel_context num_rels env)
      all_rels)
 

--- a/plugin/src/library/proofsearch/representation/cutlemma.ml
+++ b/plugin/src/library/proofsearch/representation/cutlemma.ml
@@ -7,6 +7,8 @@ open Coqterms
 open Debruijn
 open Collections
 
+module CRD = Context.Rel.Declaration
+
 type cut_lemma =
   {
     lemma : types;
@@ -75,10 +77,10 @@ let rec is_cut env lemma typ =
        is_cut_strict env lemma typ
      else
        if convertible env tl tt then
-         is_cut (push_rel (nl, None, tl) env) bl bt
+         is_cut (push_rel CRD.(LocalAssum(nl, tl)) env) bl bt
        else
-         let cut_l = is_cut (push_rel (nl, None, tl) env) bl (shift typ) in
-         let cut_r = is_cut (push_rel (nt, None, tt) env) (shift lemma) bt in
+         let cut_l = is_cut (push_rel CRD.(LocalAssum(nl, tl)) env) bl (shift typ) in
+         let cut_r = is_cut (push_rel CRD.(LocalAssum(nt, tt)) env) (shift lemma) bt in
          cut_l || cut_r
   | _  ->
      false
@@ -95,7 +97,7 @@ let has_cut_type env cut trm =
 let has_cut_type_app env cut trm =
   try
     let typ = shift (reduce_term env (infer_type env trm)) in
-    let env_cut = push_rel (Anonymous, None, get_lemma cut) env in
+    let env_cut = push_rel CRD.(LocalAssum(Anonymous, get_lemma cut)) env in
     let app = get_app cut in
     let app_app = reduce_term env_cut (mkApp (app, singleton_array (mkRel 1))) in
     let app_app_typ = infer_type env_cut app_app in
@@ -108,7 +110,7 @@ let consistent_with_cut env cut trm =
   let rec consistent en c t =
     match kinds_of_terms (c, t) with
     | (Prod (n, t, cb), Lambda (_, _, b)) when isProd cb && isLambda b ->
-       consistent (push_rel (n, None, t) en) cb b
+       consistent (push_rel CRD.(LocalAssum(n, t)) en) cb b
     | (Prod (_, ct, cb), Lambda (_, _, _)) ->
        true
     | _ ->
@@ -131,7 +133,7 @@ let filter_consistent_cut env cut trms =
   let rec make_consistent en c t =
     match kinds_of_terms (c, t) with
     | (Prod (n, t, cb), Lambda (_, _, b)) when isProd cb && isLambda b ->
-       make_consistent (push_rel (n, None, t) en) cb b
+       make_consistent (push_rel CRD.(LocalAssum(n, t)) en) cb b
     | _ ->
        t
   in

--- a/plugin/src/library/proofsearch/representation/merging.ml
+++ b/plugin/src/library/proofsearch/representation/merging.ml
@@ -8,6 +8,8 @@ open Collections
 open Coqterms
 open Coqenvs
 
+module CRD = Context.Rel.Declaration
+
 type merged_closure = env * types list * types list
 
 (* TODO needs cleanup, testing -- and when you test, see if you can change shifting to homogenous *)
@@ -28,11 +30,10 @@ let merge_environments (env1 : env) (env2 : env) (assums : equal_assumptions) : 
            (env, shift_assums substs, l)
          else
            let shift_assums = map_tuple shift_assumptions in
-           let (n, b, t) = lookup_rel i env2 in
+           let decl = lookup_rel i env2 in
            let substitute = substitute_assumptions (fold_tuple union_assumptions substs) in
-           let t' = substitute t in
-           let b' = Option.map substitute b in
-           (push_rel (n, b', t') env, shift_assums substs, (n, b', t') :: l))
+           let decl = CRD.map_constr substitute decl in
+           (push_rel decl env, shift_assums substs, decl :: l))
        (env1, split_assums, [])
        (List.rev (all_rel_indexes env2))
   in env_merged

--- a/plugin/src/library/proofsearch/representation/proofcatterms.ml
+++ b/plugin/src/library/proofsearch/representation/proofcatterms.ml
@@ -12,6 +12,8 @@ open Collections
 open Coqterms
 open Printing
 
+module CRD = Context.Rel.Declaration
+
 (* --- Construction --- *)
 
 (* Get the extension for a trm in env *)
@@ -186,7 +188,7 @@ let curry_lambda (e : extension) : extension =
   assert (ext_is_lambda e);
   let LazyBinding (trm, env) = e in
   let (n, t, b) = destLambda trm in
-  ext_of_term (push_rel (n, None, t) env) b
+  ext_of_term (push_rel CRD.(LocalAssum(n, t)) env) b
 
 (* --- Finding terms and environments --- *)
 

--- a/plugin/src/patcher.ml4
+++ b/plugin/src/patcher.ml4
@@ -9,6 +9,7 @@ open Evaluation
 open Proofdiff
 open Search
 open Constrexpr
+open Constrarg
 open Substitution
 open Printing
 open Inverting


### PR DESCRIPTION
- 99% of the patching is due to the dubious `Context` representation
  change in Coq upstream.
- update gitignore for newer ocaml versions.
- add .merlin file