### PR TITLE
Simple rewrite tactic decompilation

### DIFF
--- a/plugin/src/compilation/decompiler.ml
+++ b/plugin/src/compilation/decompiler.ml
@@ -70,11 +70,11 @@ let tac_from_term env trm : tact list =
     match kind trm with
     (* "fun x => ..." -> "intro x." *)
     | Lambda (n, t, b) ->
+       let in_env = get_pushed_names env in
        let name = match n with
-         | Anonymous ->
-            let in_env = get_pushed_names env in
-            fresh_id_in_env in_env (Id.of_string "H") env
+         | Anonymous -> Id.of_string "H"
          | Name n -> n in
+       let name = fresh_id_in_env in_env name env in
        let env = push_local (Name name, t) env in
        Intro name :: first_pass env b
     (* Match on well-known functions used in the proof. *)

--- a/plugin/src/compilation/decompiler.ml
+++ b/plugin/src/compilation/decompiler.ml
@@ -6,7 +6,9 @@ open Envutils
 open Tactics
 open Pp
 open Contextutils
-
+open Equtils
+open Apputils
+   
 (* Abstraction of Coq tactics supported by this decompiler.
    Serves as an intermediate representation that can be either
    transformed into a string or a sequence of actual tactics. *)
@@ -14,6 +16,8 @@ type tact =
   | Intro of Id.t
   | Intros of Id.t list
   | Apply of env * types
+  (* Proof that x = y if true, y = x if false. *)
+  | Rewrite of env * types * bool
         
 (* Return the string representation of a single tactic. *)
 let show_tact sigma tac : Pp.t =
@@ -24,8 +28,12 @@ let show_tact sigma tac : Pp.t =
       str ("intros " ^ names)
    | Apply (env, trm) ->
       let body_s = Printer.pr_constr_env env sigma trm in
-      str "apply " ++ body_s)
-  ++ str ".\n" (* maybe ";" in future *)
+      str "apply " ++ body_s
+   | Rewrite (env, trm, left) ->
+      let s = Printer.pr_constr_env env sigma trm in
+      let arrow = if left then "<- " else "" in
+      str ("rewrite " ^ arrow) ++ s)
+  ++ str ".\n"
 
 (* Converts "intro n. intro m. ..." into "intros n m ..." *)
 let collapse_intros (tacs : tact list) : tact list =
@@ -52,7 +60,17 @@ let get_pushed_names env =
          | Anonymous ->
             failwith "Unexpected Anonymous in get_pushed_names."
          | Name n -> n) names)
-    
+
+(* Functions used with the rewrite tactic. *)
+let is_rewrite_r trm : bool =
+  let eq_term = equal trm in
+  eq_term eq_ind_r || eq_term eq_rec_r (* || eq_term eq_rect_r *)
+  
+(* Rewrite functions using "<-". *)
+let is_rewrite_l trm : bool =
+  let eq_term = equal trm in
+  eq_term eq_ind || eq_term eq_rec (* || eq_term eq_rect*)
+
 (* Decompile a term into its equivalent tactic list. *)
 let tac_from_term env trm : tact list =
   let rec first_pass env trm =
@@ -65,13 +83,29 @@ let tac_from_term env trm : tact list =
             fresh_id_in_env in_env (Id.of_string "H") env
          | Name n -> n in
        let env = push_local (Name name, t) env in
-       (Intro name) :: first_pass env b
+       Intro name :: first_pass env b
+    (* Match on well-known functions used in the proof. *)
+    | App (f, args) ->
+       (* Applying to something that *might* be in eta-expanded 
+          form, try to reduce. *)
+       if isLambda f then
+         let app_one = mkApp (f, [|Array.get args 0|]) in
+         let beta = Reduction.whd_betaiota env app_one in
+         let app = mkApp (beta, Array.sub args 1 (Array.length args - 1)) in
+         first_pass env app
+       else
+         let left = is_rewrite_l f in
+         if left || is_rewrite_r f then
+           let prf_eq = Array.get args 5 in
+           let elem = Array.get args 3 in
+           Rewrite (env, prf_eq, left) :: first_pass env elem
+         else
+           [Apply (env, trm)]
     (* Remainder of body, simply apply it. *)
     | _ -> [Apply (env, trm)] in
   (* Perform second pass to revise greedy tactic list. *)
   collapse_intros (first_pass env trm)
-  
-  
+    
 (* Convert a tactic list into its string representation. *)
 let tac_to_string sigma (tacs : tact list) : Pp.t =
   seq (List.map (show_tact sigma) tacs)

--- a/plugin/src/patcher.ml4
+++ b/plugin/src/patcher.ml4
@@ -178,6 +178,15 @@ let patch_proof n d_old d_new cut intern =
   let search _ _ = search_for_patch old_term opts d in
   patch env n try_invert () search sigma
 
+(* Tactic to test decompilation of a single term into tactics. *)
+let decompile_tactic trm =
+  let (sigma, env) = Pfedit.get_current_context () in
+  let trm = EConstr.to_constr sigma trm in
+  let tacs = tac_from_term env trm in
+  Feedback.msg_info (tac_to_string sigma tacs);
+  Tacticals.New.tclIDTAC
+    
+  
 (* Convert constr's from patch tactics to appropriate term type. *)
 let intern_tactic env d_old d_new sigma =
   (sigma, (unwrap_definition env (EConstr.to_constr sigma d_old),
@@ -302,6 +311,11 @@ END
 TACTIC EXTEND suggest_tactic
 | [ "suggest" "patch" constr(d_old) constr(d_new) ] ->
    [ suggest_patch_tactic d_old d_new ]
+END
+
+TACTIC EXTEND decompile
+| [ "decompile" constr(trm) ] ->
+   [ decompile_tactic trm ]
 END
 
 (* --- Vernac syntax --- *)


### PR DESCRIPTION
Simple cases:
* `rewrite H`
* `rewrite <- H`
* Sequences of the above.
* Simplifies `eq_ind` etc. from eta expanded form 

[./build.sh && ./test.sh](https://github.com/uwplse/PUMPKIN-PATCH/files/4237618/output.txt)



